### PR TITLE
Feature: Added Discord Activity Indicator

### DIFF
--- a/src/main/java/uk/co/angrybee/joe/DiscordClient.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordClient.java
@@ -110,6 +110,10 @@ public class DiscordClient extends ListenerAdapter {
         }
     }
 
+    public static void onServerPlayerCountChange(int playerCount) {
+        javaDiscordAPI.getPresence().setActivity(Activity.watching(playerCount + "/" + DiscordWhitelister.getMaximumAllowedPlayers() + " players."));
+    }
+
     @Override
     public void onMessageReceived(MessageReceivedEvent messageReceivedEvent) {
         if (messageReceivedEvent.isFromType(ChannelType.TEXT)) {

--- a/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
@@ -5,6 +5,10 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.event.Listener;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import uk.co.angrybee.joe.Commands.CommandAbout;
 import uk.co.angrybee.joe.Commands.CommandStatus;
 
@@ -12,7 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-public class DiscordWhitelister extends JavaPlugin
+public class DiscordWhitelister extends JavaPlugin implements Listener
 {
     private static File whitelisterBotConfigFile;
     private static File userListFile;
@@ -113,6 +117,9 @@ public class DiscordWhitelister extends JavaPlugin
                 getLogger().severe("Discord Client failed to initialize, please check if your config file is valid.");
             }
         }
+
+        this.getServer().getPluginManager().registerEvents(this, this);
+
     }
 
     public static JavaPlugin getPlugin()
@@ -170,6 +177,20 @@ public class DiscordWhitelister extends JavaPlugin
         getUserList().set(userId, new ArrayList<>());
         getUserList().save(getUserListFile().getPath());
     }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        DiscordClient.onServerPlayerCountChange(getOnlineUsers());
+    }
+
+    @EventHandler
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        DiscordClient.onServerPlayerCountChange(getOnlineUsers() - 1);
+    }
+
+    public static int getOnlineUsers() { return thisPlugin.getServer().getOnlinePlayers().size(); }
+
+    public static int getMaximumAllowedPlayers() { return thisPlugin.getServer().getMaxPlayers(); }
 
     public void ConfigSetup()
     {

--- a/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
@@ -119,6 +119,7 @@ public class DiscordWhitelister extends JavaPlugin implements Listener
         }
 
         this.getServer().getPluginManager().registerEvents(this, this);
+        DiscordClient.onServerPlayerCountChange(getOnlineUsers());
 
     }
 


### PR DESCRIPTION
Hi there,

I liked using the plugin but I wanted to incorporate a way to show the number of users online for the Discord Bot's activity. Here is an example of what I added with these changes.

![image](https://user-images.githubusercontent.com/8432510/79722918-c41c0800-8299-11ea-8604-76d075d6227a.png)

![image](https://user-images.githubusercontent.com/8432510/79722959-d1d18d80-8299-11ea-8783-bc5201cd83b7.png)

- On server start, it sets the Discord Bot's Activity to "Watching 0/[MaxPlayers] players."

- Upon user joining or leaving the Bot's Activity updates accordingly.

I didn't update the version info or metadata in the case that these changes aren't permitted.
Thanks! Let me know if you have any questions.
