### PR TITLE
Added option to add/remove a role to users after whitelisting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,29 @@ If you upgrade without knowing what you are doing. Registration will not work co
 	- **limited-add group**: allows the user to whitelist a limited amount of times (recommended for users, default amount is 3)
 	- limited-add group can be disabled in the config (enabled by default)
 	
-- removed list:
-	- this list removes the ability for limited-add users to add back users that have been removed by the add-remove group
-	- can be disabled in the config (enabled by default)
+- Removed list:
+	- This list removes the ability for limited-add users to add back users that have been removed by the add-remove group
+	- Can be disabled in the config (enabled by default)
 
-- use '!whitelist add "minecraftUsername"' in a valid channel to whitelist people on your minecraft server
-- use '!whitelist remove "minecraftUsername"' in a valid channel to remove people from the whitelist on your minecraft server
-- use '!whitelist' in a valid channel to get info about the bot and how to use it
+- Discord commands:
+    - Use `!whitelist add "minecraftUsername"` in a valid channel to whitelist people on your minecraft server
+    - Use `!whitelist remove "minecraftUsername"` in a valid channel to remove people from the whitelist on your minecraft server
+    - Use `!whitelist` in a valid channel to get info about the bot and how to use it
 
-- only select Discord roles can whitelist through the bot
-- bot only listens for messages in select text channels
-- logs whitelist attempts from valid roles in the console
+- Automatically add/remove a role when adding/removing to/from the whitelist
+    - This feature is meant to be used when users can add themselves to the whitelist.
+    - If `whitelisted-role-auto-add` is set to true (false by default), the Discord role with the name defined by `whitelisted-role` ("Whitelisted" by default) will be added to that user when they successfully add (themselves) to the whitelist.
+    - If `whitelisted-role-auto-remove` is set to true (false by default), that role will be removed from that user when they successfully remove (themselves) from the whitelist.
+    - This requires:
+        - The bot to have the `Manage Roles` permission in Discord
+        - Setting up a Discord role with the same name (case sensitive) as the config
+        - The bot's role must be higher than the whitelist role 
+
+- Only select Discord roles can whitelist through the bot
+- Bot only listens for messages in select text channels
+- Logs whitelist attempts from valid roles in the console
 
 ### Set Up:
 
-Config file is located at: (server-root)/plugins/DiscordWhitelister - this needs a valid bot token and valid channel ids to work.
+Config file is located at: (server-root)/plugins/DiscordWhitelister - this needs a valid bot token and valid channel id(s) to work.
 To create a Discord application and/or find your discord bot token, follow this link: https://discordapp.com/developers/applications/

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: DiscordWhitelister
-version: 1.2.0
+version: 1.3.0
 author: Joe Shimell
 main: uk.co.angrybee.joe.DiscordWhitelister
 description: Discord whitelister bot.

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <name>discord-whitelister</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <url>https://github.com/JoeShimell/DiscordWhitelisterSpigot</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/uk/co/angrybee/joe/Commands/CommandAbout.java
+++ b/src/main/java/uk/co/angrybee/joe/Commands/CommandAbout.java
@@ -11,7 +11,7 @@ import uk.co.angrybee.joe.VersionInfo;
 public class CommandAbout implements CommandExecutor {
 
     // /dw
-    // version command
+    // about command
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         sender.sendMessage("[DW] DiscordWhiteLister by JoeShimell\nhttps://github.com/JoeShimell/DiscordWhitelisterSpigot");

--- a/src/main/java/uk/co/angrybee/joe/Commands/CommandStatus.java
+++ b/src/main/java/uk/co/angrybee/joe/Commands/CommandStatus.java
@@ -11,7 +11,7 @@ import uk.co.angrybee.joe.VersionInfo;
 public class CommandStatus implements CommandExecutor {
 
     // /dw
-    // version command
+    // version & status command
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         String discordOnlineStatus = DiscordClient.getOnlineStatus();

--- a/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordWhitelister.java
@@ -376,6 +376,39 @@ public class DiscordWhitelister extends JavaPlugin
                 }
             }
 
+            // If adding the whitelisted role to the discord user is enabled
+            if(getWhitelisterBotConfig().get("whitelisted-role-auto-add") == null)
+            {
+                getWhitelisterBotConfig().set("whitelisted-role-auto-add", false);
+
+                if(!configCreated)
+                {
+                    getPlugin().getLogger().warning("Entry 'whitelisted-role-auto-add' was not found, adding it to the config...");
+                }
+            }
+
+            // If removing the whitelisted role from the discord user is enabled
+            if(getWhitelisterBotConfig().get("whitelisted-role-auto-remove") == null)
+            {
+                getWhitelisterBotConfig().set("whitelisted-role-auto-remove", false);
+
+                if(!configCreated)
+                {
+                    getPlugin().getLogger().warning("Entry 'whitelisted-role-auto-remove' was not found, adding it to the config...");
+                }
+            }
+
+            // The name of the role to add/remove to the user
+            if(getWhitelisterBotConfig().get("whitelisted-role") == null)
+            {
+                getWhitelisterBotConfig().set("whitelisted-role", "Whitelisted");
+
+                if(!configCreated)
+                {
+                    getPlugin().getLogger().warning("Entry 'whitelisted-role' was not found, adding it to the config...");
+                }
+            }
+
             // easy whitelist support
             if(getWhitelisterBotConfig().get("use-easy-whitelist") == null)
             {


### PR DESCRIPTION
This feature is meant to be used when users have the ability to whitelist themselves (limited-add-roles).
If whitelisted-role-auto-add is set to true (false by default), the Discord role with the name defined by whitelisted-role ("Whitelisted" by default) will be added when the user successfully adds to the whitelist.
If whitelisted-role-auto-remove is set to true (false by default), that role will be removed when the user successfully removes from the whitelist.