### PR TITLE
Made !whitelist add/remove commands required to be at start of message.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,14 +1,14 @@
 name: DiscordWhitelister
-version: 1.3.0
+version: 1.3.1
 author: Joe Shimell
 main: uk.co.angrybee.joe.DiscordWhitelister
 description: Discord whitelister bot.
 commands:
   discordwhitelister:
-    description: See VersionInfo and Discord status
+    description: See info about this plugin
     usage: /<command>
     aliases: [dw]
   discordwhitelisterabout:
-    description: See VersionInfo and Discord status
+    description: See plugin version and Discord connection status
     usage: /<command>
     aliases: [dwabout]

--- a/src/main/java/uk/co/angrybee/joe/Commands/CommandAbout.java
+++ b/src/main/java/uk/co/angrybee/joe/Commands/CommandAbout.java
@@ -10,11 +10,11 @@ import uk.co.angrybee.joe.VersionInfo;
 
 public class CommandAbout implements CommandExecutor {
 
-    // /dw
+    // /dwabout
     // about command
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        sender.sendMessage("[DW] DiscordWhiteLister by JoeShimell\nhttps://github.com/JoeShimell/DiscordWhitelisterSpigot");
+        sender.sendMessage("[DW] DiscordWhiteLister by JoeShimell\n" + ChatColor.GREEN + "https://github.com/JoeShimell/DiscordWhitelisterSpigot");
         return true;
     }
 }

--- a/src/main/java/uk/co/angrybee/joe/Events/JoinLeaveEvents.java
+++ b/src/main/java/uk/co/angrybee/joe/Events/JoinLeaveEvents.java
@@ -14,12 +14,24 @@ public class JoinLeaveEvents implements Listener
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event)
     {
+        if(event.getPlayer().hasPermission("discordsrv.silentjoin") ||
+                event.getPlayer().hasPermission("discordsrv.silentquit") ||
+                event.getPlayer().hasPermission("sv.joinvanished")) {
+            DiscordWhitelister.getPlugin().getLogger().info("Player " + event.getPlayer().getDisplayName() + " joined with silent joining/quitting permission, not incrementing player count");
+            return;
+        }
         DiscordClient.SetPlayerCountStatus(DiscordWhitelister.getOnlineUsers());
     }
 
     @EventHandler
     public void onPlayerLeave(PlayerQuitEvent event)
     {
+        if(event.getPlayer().hasPermission("discordsrv.silentjoin") ||
+                event.getPlayer().hasPermission("discordsrv.silentquit") ||
+                event.getPlayer().hasPermission("sv.joinvanished")) {
+            DiscordWhitelister.getPlugin().getLogger().info("Player " + event.getPlayer().getDisplayName() + " quit with silent joining/quitting permission, not decrementing player count");
+            return;
+        }
         DiscordClient.SetPlayerCountStatus(DiscordWhitelister.getOnlineUsers() - 1);
     }
 }

--- a/src/main/java/uk/co/angrybee/joe/VersionInfo.java
+++ b/src/main/java/uk/co/angrybee/joe/VersionInfo.java
@@ -9,5 +9,5 @@ public class VersionInfo {
         return "v." + getVersion();
     }
 
-    private static String version = "1.2.0";
+    private static String version = "1.3.1";
 }


### PR DESCRIPTION
Made the name be the text up to the first space following the command (everything else is ignored).
This allows writing something like "@user please do !whitelist add <username>" without triggering the bot.

Fixed error that occurred when users leave guild which did not use the plugin to add to the whitelist.
Fixed version not displaying correctly (was still showing 1.2.0).
Made GitHub link in /dwabout command green.