### PR TITLE
Added compatibility with GeyserMC/Floodgate

### DIFF
--- a/src/main/java/uk/co/angrybee/joe/commands/discord/CommandAdd.java
+++ b/src/main/java/uk/co/angrybee/joe/commands/discord/CommandAdd.java
@@ -473,6 +473,9 @@ public class CommandAdd
 
                 if (!WhitelistedPlayers.usingEasyWhitelist && authorPermissions.isUserCanUseCommand())
                     DiscordClient.ExecuteServerCommand("whitelist add " + finalNameToAdd);
+                    if(MainConfig.getMainConfig().getBoolean("use-geyser/floodgate-compatibility")) {
+                        addBedrockUser(finalNameToAdd);
+                    }
 
                 // have to use !invalidMinecraftName else the easy whitelist plugin will add the name regardless of whether it is valid on not
                 if (WhitelistedPlayers.usingEasyWhitelist && !invalidMinecraftName && authorPermissions.isUserCanUseCommand())
@@ -613,6 +616,18 @@ public class CommandAdd
                     return null;
                 });
             }
+        }
+    }
+
+    private static void addBedrockUser(String finalNameToAdd) {
+        String bedrockPrefix = MainConfig.getMainConfig().getString("geyser/floodgate prefix");
+        String bedrockName = bedrockPrefix + finalNameToAdd;
+        if(bedrockName.length() > 16) {
+            bedrockName = bedrockName.substring(0, 16);
+        }
+        //check if we actually NEED to add
+        if(finalNameToAdd.length() < bedrockPrefix.length() || !finalNameToAdd.substring(0, bedrockPrefix.length() - 1).equals(bedrockPrefix)) {
+            DiscordClient.ExecuteServerCommand("whitelist add " + bedrockName);
         }
     }
 }

--- a/src/main/java/uk/co/angrybee/joe/configs/MainConfig.java
+++ b/src/main/java/uk/co/angrybee/joe/configs/MainConfig.java
@@ -157,6 +157,10 @@ public class MainConfig
 
         CheckEntry("use-crafatar-for-avatars", false);
 
+        CheckEntry("use-geyser/floodgate-compatibility", false);
+
+        CheckEntry("geyser/floodgate prefix", "SetThisToWhateverPrefixYouUse");
+
         // Remove old role entry if found, move role to new array (for people with v1.3.6 or below)
         if(whitelisterBotConfig.get("whitelisted-role") != null)
         {


### PR DESCRIPTION
GeyserMC and Floodgate are plugins for letting Bedrock players use Java servers. Often, servers that use these plugins will append a prefix to Bedrock usernames to prevent conflicts with Java usernames. With my changes enabled in the config, the modified username can be generated and be added to the whitelist along with what the user originally entered.

This way user who doesn't realize that the usernames are being changed for compatibility, or doesn't know how to figure out their altered username, can just enter their Xbox Live gamertag and will still be whitelisted correctly.